### PR TITLE
Allow scrolling the table of contents if necessary

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,8 @@
     .pagetoc {
         position: fixed;
         width: 200px;
+        height: calc(100% - var(--menu-bar-height));
+        overflow: auto;
     }
     .pagetoc a {
         border-left: 1px solid var(--sidebar-bg);


### PR DESCRIPTION
Fixes #3 by adding a scrollbar to the table of contents if its contents extend past the border of the screen.

Before:

![image](https://user-images.githubusercontent.com/1342360/119284290-41e9da00-bc37-11eb-9204-9f18ae71bbe9.png)

(you can't actually view the later table of contents items)

After:

![image](https://user-images.githubusercontent.com/1342360/119284271-34cceb00-bc37-11eb-8a1f-e95afa1d4e24.png)

This does not affect content that does not require a scrollbar:

![image](https://user-images.githubusercontent.com/1342360/119284324-5af28b00-bc37-11eb-9176-da0bc20d17be.png)
