### PR TITLE
Prevent visited ToC headers from changing colour

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@
     }
     .pagetoc a {
         border-left: 1px solid var(--sidebar-bg);
-        color: var(--fg);
+        color: var(--fg) !important;
         display: block;
         padding-bottom: 5px;
         padding-top: 5px;


### PR DESCRIPTION
Prevents headers from changing color once you click on them.

Before:

![image](https://user-images.githubusercontent.com/1342360/119284474-b290f680-bc37-11eb-833c-02b4e6f99142.png)

(notice the mix of blue and white in the sidebar headers. white are visited, blue are not visited).

After:

![image](https://user-images.githubusercontent.com/1342360/119284523-d0f6f200-bc37-11eb-8d0c-bcfd16e462ab.png)

Now all titles are consistent! Why is this necessary? It turns out that there's a very generic `a:visited { color: var(--links) }` in mdbook's `chrome.css` file which ends up coloring the ToC header links if you've clicked on them previously. See [the source](https://github.com/rust-lang/mdBook/blob/7e7e779ef7ae29ac051858b7e8c27843880c2366/src/theme/css/chrome.css#L16).

By adding `!important`, we override that for the elements matched by `.pagetoc a`, and ignore the global selector.