### PR TITLE
Hide .sidetoc when printing

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,3 +40,9 @@
         color: var(--sidebar-fg);
     }
 }
+
+@media print {
+    .sidetoc {
+        display: none;
+    }
+}


### PR DESCRIPTION
The sidetoc text is part of the print output (`print.html`) which doesn't seem desirable.

This solution `works for me`™ and removes the text as expected.