### PR TITLE
Fix theme switching error by adding missing IDs to highlight stylesheets

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -39,9 +39,9 @@
         {{/if}}
 
         <!-- Highlight.js Stylesheets -->
-        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
-        <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
-        <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}highlight.css" id="highlight-css">
+        <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css" id="tomorrow-night-css">
+        <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css" id="ayu-highlight-css">
 
         <!-- Custom theme stylesheets -->
         {{#each additional_css}}


### PR DESCRIPTION
When I load the mdbook server document, the web console will prompt:
```
book.js:393 Uncaught TypeError: Cannot set properties of null (setting 'disabled')
    at set_theme (book.js:393:47)
    at themes (book.js:429:5)
    at book.js:515:3
```
The main reason is that stylesheets.ayuHighlight is empty, triggering an empty exception:
```
    function set_theme(theme, store = true) {
        let ace_theme;

        if (theme === 'coal' || theme === 'navy') {
            stylesheets.ayuHighlight.disabled = true;
            stylesheets.tomorrowNight.disabled = false;
            stylesheets.highlight.disabled = true;

            ace_theme = 'ace/theme/tomorrow_night';
        } else if (theme === 'ayu') {
            stylesheets.ayuHighlight.disabled = false;
            stylesheets.tomorrowNight.disabled = true;
            stylesheets.highlight.disabled = true;
            ace_theme = 'ace/theme/tomorrow_night';
        } else {
            stylesheets.ayuHighlight.disabled = true; <------ Cause Exception
            stylesheets.tomorrowNight.disabled = true;
            stylesheets.highlight.disabled = false;
            ace_theme = 'ace/theme/dawn';
        }
```

Printing `stylesheets` results in `{ayuHighlight: null, tomorrowNight: null, highlight: null}`. The `definition` of stylesheets is
```
    const stylesheets = {
        ayuHighlight: document.querySelector('#ayu-highlight-css'),
        tomorrowNight: document.querySelector('#tomorrow-night-css'),
        highlight: document.querySelector('#highlight-css'),
    };
```

Furthermore, this error further causes the theme to be unable to switch, and clicking the theme switch button does not pop up the menu. Fixing this bug to switch themes normally is urgent!